### PR TITLE
fixed IsNotDefault for reference types

### DIFF
--- a/CodeGuard/ObjectValidatorExtensions.cs
+++ b/CodeGuard/ObjectValidatorExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Seterlund.CodeGuard.Internals;
 using System.Linq;
 
 namespace Seterlund.CodeGuard
@@ -28,10 +27,20 @@ namespace Seterlund.CodeGuard
         /// <returns></returns>
         public static IArg<T> IsNotDefault<T>(this IArg<T> arg)
         {
-            if (default(T).Equals(arg.Value))
+            T defautlValue = default(T);
+            if (defautlValue == null)
             {
-                arg.Message.Set("Value cannot be the default value.");
-
+                if (arg.Value == null)
+                {
+                    arg.Message.Set("Value cannot be the default value.");
+                }
+            }
+            else
+            {
+                if (default(T).Equals(arg.Value))
+                {
+                    arg.Message.Set("Value cannot be the default value.");
+                }
             }
 
             return arg;

--- a/UnitTests/ObjectValidatorTests.cs
+++ b/UnitTests/ObjectValidatorTests.cs
@@ -81,7 +81,7 @@ namespace Seterlund.CodeGuard.UnitTests
         }
 
         [Test]
-        public void IsNotDefault_WhenArgumentIsDefault_Throws()
+        public void IsNotDefault_WhenArgumentIsValueTypeAndValueIsDefault_Throws()
         {
             // Arrange
             int arg1 = default(int);
@@ -95,10 +95,37 @@ namespace Seterlund.CodeGuard.UnitTests
         }
 
         [Test]
-        public void IsNotDefault_WhenArgumentIsNotDefault_DoesNotThrow()
+        public void IsNotDefault_WhenArgumentIsValueTypeAndValueIsNotDefault_DoesNotThrow()
         {
             // Arrange
             int arg1 = default(int) + 1;
+
+            // Act/Assert
+            Assert.DoesNotThrow(() =>
+            {
+                Guard.That(() => arg1).IsNotDefault();
+            });
+        }
+
+        [Test]
+        public void IsNotDefault_WhenArgumentIsReferenceTypeAndValueIsDefault_Throws()
+        {
+            // Arrange
+            object arg1 = null;
+
+            // Act
+            ArgumentException exception =
+                GetException<ArgumentException>(() => Guard.That(() => arg1).IsNotDefault());
+
+            // Assert
+            AssertArgumentException(exception, "arg1", "Value cannot be the default value.\r\nParameter name: arg1");
+        }
+
+        [Test]
+        public void IsNotDefault_WhenArgumentIsReferenceTypeAndValueIsNotDefault_DoesNotThrow()
+        {
+            // Arrange
+            object arg1 = new object();
 
             // Act/Assert
             Assert.DoesNotThrow(() =>


### PR DESCRIPTION
 - [x] unit tests
 - [x] implementation

I've fixed that:

    Guard.That(() => foo).IsNotDefault();

did not work when `foo` is a reference type (like `object`). Rather, it resulted in a `NullReferenceException`,  at `default(T).Equals(...)` (because `default(typeof(object)) == null`).